### PR TITLE
Add GCIDE plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@
 - [pot-app-translate-plugin-libre](https://github.com/Integral-Tech/pot-app-translate-plugin-libre) - LibreTranslate 翻译插件
 - [pot-app-translate-plugin-freedict](https://github.com/Integral-Tech/pot-app-translate-plugin-freedict) - Free Dictionary API 英英词典插件
 - [pot-app-translate-plugin-azure](https://github.com/ElmTran/pot-app-translate-plugin-azure) - Azure 翻译插件
+- [pot-app-translate-plugin-gcide](https://github.com/wu-yufei/pot-app-translate-plugin-gcide) - 离线 英英词典插件 (基于[GCIDE](https://gcide.gnu.org.ua))
 
 ## 文字识别
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -43,6 +43,7 @@ Pot app plugin collection from the community.
 - [pot-app-translate-plugin-libre](https://github.com/Integral-Tech/pot-app-translate-plugin-libre) - LibreTranslate translate plugin
 - [pot-app-translate-plugin-freedict](https://github.com/Integral-Tech/pot-app-translate-plugin-freedict) - Free Dictionary API translate plugin
 - [pot-app-translate-plugin-azure](https://github.com/ElmTran/pot-app-translate-plugin-azure) - Azure translate plugin
+- [pot-app-translate-plugin-gcide](https://github.com/wu-yufei/pot-app-translate-plugin-gcide) - Offline English-English dictionary plugin (base on [GCIDE](https://gcide.gnu.org.ua))
 
 ## Recognize
 

--- a/list.json
+++ b/list.json
@@ -137,6 +137,14 @@
         "url": "https://github.com/ElmTran/pot-app-translate-plugin-azure",
         "offical": false,
         "illegal": false
+    },
+    {
+      "name": "pot-app-translate-plugin-gcide",
+        "desc_en": "Offline English-English dictionary plugin (base on GCIDE)",
+        "desc_zh": "离线 英英词典插件 (基于 GCIDE)",
+        "url": "https://github.com/wu-yufei/pot-app-translate-plugin-gcide",
+        "offical": false,
+        "illegal": false
     }
   ],
   "recognize": [


### PR DESCRIPTION
本插件提供离线英英词典，基于[GCIDE](https://gcide.gnu.org.ua/)。GCIDE，GNU Collaborative International Dictionary of English，是由 1913 年版 *Webster's Revised Unabridged Dictionary* （韦氏词典）衍生而来的自由词典，主要通过 [Wordnet](http://wordnet.princeton.edu/) 增补了新的释义。