### PR TITLE
Add Deepseek translation plugin to list.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 - [pot-app-translate-plugin-azure](https://github.com/ElmTran/pot-app-translate-plugin-azure) - Azure 翻译插件
 - [pot-app-translate-plugin-gcide](https://github.com/wu-yufei/pot-app-translate-plugin-gcide) - 离线 英英词典插件 (基于[GCIDE](https://gcide.gnu.org.ua))
 - [pot-app-translate-plugin-cohere](https://github.com/omegaduncan/pot-app-translate-plugin-cohere) - Cohere 翻译插件
-- [pot-app-translate-plugin-deepseek](https://github.com/Tzulao55/pot-app-translate-plugin-deepseek) - deepseek 翻译插件
+- [pot-app-translate-plugin-deepseek](https://github.com/Tzulao55/pot-app-translate-plugin-deepseek) - DeepSeek 翻译插件
 
 ## 文字识别
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [pot-app-translate-plugin-azure](https://github.com/ElmTran/pot-app-translate-plugin-azure) - Azure 翻译插件
 - [pot-app-translate-plugin-gcide](https://github.com/wu-yufei/pot-app-translate-plugin-gcide) - 离线 英英词典插件 (基于[GCIDE](https://gcide.gnu.org.ua))
 - [pot-app-translate-plugin-cohere](https://github.com/omegaduncan/pot-app-translate-plugin-cohere) - Cohere 翻译插件
+- [pot-app-translate-plugin-deepseek](https://github.com/Tzulao55/pot-app-translate-plugin-deepseek) - deepseek 翻译插件
 
 ## 文字识别
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -45,7 +45,7 @@ Pot app plugin collection from the community.
 - [pot-app-translate-plugin-azure](https://github.com/ElmTran/pot-app-translate-plugin-azure) - Azure translate plugin
 - [pot-app-translate-plugin-gcide](https://github.com/wu-yufei/pot-app-translate-plugin-gcide) - Offline English-English dictionary plugin (base on [GCIDE](https://gcide.gnu.org.ua))
 - [pot-app-translate-plugin-cohere](https://github.com/omegaduncan/pot-app-translate-plugin-cohere) - Cohere translate plugin
-- [pot-app-translate-plugin-deepseek](https://github.com/Tzulao55/pot-app-translate-plugin-deepseek) - deepseek translate plugin
+- [pot-app-translate-plugin-deepseek](https://github.com/Tzulao55/pot-app-translate-plugin-deepseek) - DeepSeek translate plugin
 
 ## Recognize
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -45,6 +45,7 @@ Pot app plugin collection from the community.
 - [pot-app-translate-plugin-azure](https://github.com/ElmTran/pot-app-translate-plugin-azure) - Azure translate plugin
 - [pot-app-translate-plugin-gcide](https://github.com/wu-yufei/pot-app-translate-plugin-gcide) - Offline English-English dictionary plugin (base on [GCIDE](https://gcide.gnu.org.ua))
 - [pot-app-translate-plugin-cohere](https://github.com/omegaduncan/pot-app-translate-plugin-cohere) - Cohere translate plugin
+- [pot-app-translate-plugin-deepseek](https://github.com/Tzulao55/pot-app-translate-plugin-deepseek) - deepseek translate plugin
 
 ## Recognize
 

--- a/list.json
+++ b/list.json
@@ -156,8 +156,8 @@
     },
     {
     "name": "pot-app-translate-plugin-deepseek",
-    "desc_en": "Translation plugin based on DeepSeek API, supporting multiple languages with two model options",
-    "desc_zh": "基于DeepSeek API的翻译插件，支持多语言翻译，提供两种模型选择",
+    "desc_en": "DeepSeek translate plugin",
+    "desc_zh": "DeepSeek 翻译插件",
     "url": "https://github.com/Tzulao55/pot-app-translate-plugin-deepseek",
     "offical": false,
     "illegal": false

--- a/list.json
+++ b/list.json
@@ -153,6 +153,14 @@
       "url": "https://github.com/omegaduncan/pot-app-translate-plugin-cohere",
       "offical": false,
       "illegal": false
+    },
+    {
+    "name": "pot-app-translate-plugin-deepseek",
+    "desc_en": "Translation plugin based on DeepSeek API, supporting multiple languages with two model options",
+    "desc_zh": "基于DeepSeek API的翻译插件，支持多语言翻译，提供两种模型选择",
+    "url": "https://github.com/Tzulao55/pot-app-translate-plugin-deepseek",
+    "offical": false,
+    "illegal": false
     }
   ],
   "recognize": [


### PR DESCRIPTION
# deepseek Translation Plugin

添加基于deepseek API的翻译插件到插件列表。

## 主要特点
- 支持两种模型选择：deepseek-chat 和 deepseek-reasoner
- 支持多语言翻译
- 提供专业、流畅的翻译结果
- 简单易用的配置界面

## 技术细节
- 插件ID: plugin.com.TzuLao.deepseek
- 版本: v1.0.0
- 仓库地址: https://github.com/Tzulao55/pot-app-translate-plugin-deepseek

## 测试情况
- 功能测试完成
- 支持所有pot-app标准语言代码
- API调用稳定可靠

期待您的审核，如有任何问题随时告知。